### PR TITLE
ユーザーフォロー機能実装

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BooksController < ApplicationController
-  before_action :set_book, only: [:show, :edit, :update, :destroy]
+  before_action :set_book, only: [:edit, :update, :destroy]
 
   # GET /books
   def index
@@ -10,6 +10,7 @@ class BooksController < ApplicationController
 
   # GET /books/1
   def show
+    @book = Book.find(params[:id])
   end
 
   # GET /books/new
@@ -51,7 +52,7 @@ class BooksController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_book
-      @book = Book.find(params[:id])
+      @book = current_user.books.find(params[:id])
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -24,6 +24,7 @@ class BooksController < ApplicationController
   # POST /books
   def create
     @book = Book.new(book_params)
+    @book.user_id = current_user.id
 
     if @book.save
       redirect_to @book, notice: t("flash.create")

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RelationshipsController < ApplicationController
+  def create
+    user = User.find(params[:followed_id])
+    current_user.follow(user)
+    redirect_to user
+  end
+
+  def destroy
+    user = Relationship.find(params[:id]).followed
+    current_user.unfollow(user)
+    redirect_to user
+  end
+end

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TimelineController < ApplicationController
+  def index
+    @books = Book.where(user_id: current_user.following).page(params[:page])
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,5 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+  belongs_to :user
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -3,9 +3,4 @@
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
   belongs_to :user
-
-  def created_by?(user)
-    return false if user == nil
-    user_id == user.id
-  end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -5,6 +5,7 @@ class Book < ApplicationRecord
   belongs_to :user
 
   def created_by?(user)
-    user_id == user.id ? true : false
+    return false if user == nil
+    user_id == user.id
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -3,4 +3,8 @@
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
   belongs_to :user
+
+  def created_by?(user)
+    user_id == user.id ? true : false
+  end
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -3,6 +3,4 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: "User"
   belongs_to :followed, class_name: "User"
-  validates :follower_id, presence: true
-  validates :followed_id, presence: true
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   has_one_attached :image
+  has_many :books
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[github]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,10 @@
 class User < ApplicationRecord
   has_one_attached :image
   has_many :books
+  has_many :active_relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
+  has_many :passive_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
+  has_many :following, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[github]
@@ -38,5 +42,17 @@ class User < ApplicationRecord
     result = update_attributes(params, *options)
     clean_up_passwords
     result
+  end
+
+  def follow(other_user)
+    following << other_user
+  end
+
+  def unfollow(other_user)
+    active_relationships.find_by(followed_id: other_user.id).destroy
+  end
+
+  def following?(other_user)
+    following.include?(other_user)
   end
 end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -3,6 +3,7 @@
 <table>
   <thead>
     <tr>
+      <th><%= User.human_attribute_name(:name) %></th>
       <th><%= Book.human_attribute_name(:title) %></th>
       <th><%= Book.human_attribute_name(:memo) %></th>
       <th><%= Book.human_attribute_name(:author) %></th>
@@ -14,6 +15,7 @@
   <tbody>
     <% @books.each do |book| %>
       <tr>
+        <td><%= link_to book.user.name, user_path(book.user) %></td>
         <td><%= book.title %></td>
         <td><%= book.memo %></td>
         <td><%= book.author %></td>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -21,7 +21,7 @@
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
         <td><%= link_to t("link.Show"), book %></td>
-        <% if book.created_by?(current_user) %>
+        <% if book.user == current_user %>
           <td><%= link_to t("link.Edit"), edit_book_path(book) %></td>
           <td><%= link_to t("link.Destroy"), book, method: :delete, data: { confirm: t("alert.sure") } %></td>
         <% end %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -19,8 +19,10 @@
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
         <td><%= link_to t("link.Show"), book %></td>
-        <td><%= link_to t("link.Edit"), edit_book_path(book) %></td>
-        <td><%= link_to t("link.Destroy"), book, method: :delete, data: { confirm: t("alert.sure") } %></td>
+        <% if book.created_by?(current_user) %>
+          <td><%= link_to t("link.Edit"), edit_book_path(book) %></td>
+          <td><%= link_to t("link.Destroy"), book, method: :delete, data: { confirm: t("alert.sure") } %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,6 +1,11 @@
 <p id="notice"><%= notice %></p>
 
 <p>
+  <strong><%= User.human_attribute_name(:name) %>:</strong>
+  <%= link_to @book.user.name, user_path(@book.user) %>
+</p>
+
+<p>
   <strong><%= Book.human_attribute_name(:title) %>:</strong>
   <%= @book.title %>
 </p>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -25,7 +25,7 @@
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<% if @book.created_by?(current_user) %>
+<% if @book.user == current_user %>
   <%= link_to t("link.Edit"), edit_book_path(@book) %> |
 <% end %>
 <%= link_to t("link.Back"), books_path %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -20,5 +20,7 @@
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to t("link.Edit"), edit_book_path(@book) %> |
+<% if @book.created_by?(current_user) %>
+  <%= link_to t("link.Edit"), edit_book_path(@book) %> |
+<% end %>
 <%= link_to t("link.Back"), books_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,8 @@
   <body>
   <p>
     <% if user_signed_in? %>
+      <%= link_to t("Top"), root_path %>
+      <%= link_to t("My Timeline"), timeline_path %> |
       <%= t("Logged in as") %> <strong><%= link_to current_user.name, user_path(current_user) %></strong>
       <%= link_to t("Edit profile"), edit_user_registration_path %> |
       <%= link_to t("Logout"), destroy_user_session_path, method: :delete %>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -1,0 +1,32 @@
+<h1><%= t("My Timeline") %></h1>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= User.human_attribute_name(:name) %></th>
+      <th><%= Book.human_attribute_name(:title) %></th>
+      <th><%= Book.human_attribute_name(:memo) %></th>
+      <th><%= Book.human_attribute_name(:author) %></th>
+      <th><%= Book.human_attribute_name(:picture) %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @books.each do |book| %>
+      <tr>
+        <td><%= link_to book.user.name, user_path(book.user) %></td>
+        <td><%= book.title %></td>
+        <td><%= book.memo %></td>
+        <td><%= book.author %></td>
+        <td><%= book.picture %></td>
+        <td><%= link_to t("link.Show"), book %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+<%= paginate @books %>
+<br>
+<%= link_to t("link.New Book"), new_book_path %>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(model: current_user.active_relationships.build, local: true) do |f| %>
+  <div><%= hidden_field_tag :followed_id, @user.id %></div>
+  <%= f.submit t("Follow") %>
+<% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,0 +1,3 @@
+<%= form_with(model: current_user.active_relationships.find_by(followed_id: @user.id), local: true, html: { method: :delete }) do |f| %>
+  <%= f.submit t("Unfollow") %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,11 +1,19 @@
-<p>
-  <strong><%= User.human_attribute_name(:email) %>:</strong>
-  <%= @user.email %>
-</p>
+<% unless current_user == @user %>
+  <% if current_user.following?(@user) %>
+    <%= render "unfollow" %>
+  <% else %>
+    <%= render "follow" %>
+  <% end %>
+<% end %>
 
 <p>
   <strong><%= User.human_attribute_name(:name) %>:</strong>
   <%= @user.name %>
+</p>
+
+<p>
+  <strong><%= User.human_attribute_name(:email) %>:</strong>
+  <%= @user.email %>
 </p>
 
 <p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,7 @@ ja:
         author: 著者
         picture: 画像
       user:
+        name: ユーザー名
         image: 画像
   link:
     New Book: 新規作成
@@ -33,6 +34,10 @@ ja:
   New Book: 新規作成
   Editing Book: 編集
   Sign in with GitHub: "GitHubでログイン"
+  Top: トップ
+  My Timeline: マイタイムライン
+  Follow: フォローする
+  Unfollow: フォロー解除
   views:
     pagination:
       first: "&laquo; 最初"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,6 @@ Rails.application.routes.draw do
   end
   resources :users, only: [:show]
   resources :relationships, only: [:create, :destroy]
+  get "timeline", to: "timeline#index"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,11 @@ Rails.application.routes.draw do
     omniauth_callbacks: "users/omniauth_callbacks"
   }
   resources :books
+  resources :users do
+    member do
+      get :following, :followers
+    end
+  end
   resources :users, only: [:show]
   resources :relationships, only: [:create, :destroy]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,6 @@ Rails.application.routes.draw do
   }
   resources :books
   resources :users, only: [:show]
+  resources :relationships, only: [:create, :destroy]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20200724053156_add_user_id_to_books.rb
+++ b/db/migrate/20200724053156_add_user_id_to_books.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUserIdToBooks < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :books, :user, foreign_key: true
+    change_column :books, :user_id, :integer, null: false
+  end
+end

--- a/db/migrate/20200725153426_create_relationships.rb
+++ b/db/migrate/20200725153426_create_relationships.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateRelationships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_22_034035) do
+ActiveRecord::Schema.define(version: 2020_07_24_053156) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -41,6 +41,8 @@ ActiveRecord::Schema.define(version: 2020_07_22_034035) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "author"
     t.string "picture"
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_books_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -63,4 +65,5 @@ ActiveRecord::Schema.define(version: 2020_07_22_034035) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "books", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_24_053156) do
+ActiveRecord::Schema.define(version: 2020_07_25_153426) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -43,6 +43,16 @@ ActiveRecord::Schema.define(version: 2020_07_24_053156) do
     t.string "picture"
     t.integer "user_id", null: false
     t.index ["user_id"], name: "index_books_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## 内容

- 投稿（Book）とユーザー（User）を関連付け
- ログイン中のユーザー以外の投稿の「編集・削除」ボタンを非表示に
- 各投稿に投稿したユーザー名を表示させ、プロフィールへリンク
- ログイン中のユーザー以外のプロフィールページに「フォローする/フォロー解除」ボタンを設置
- フォローしているユーザーの投稿一覧ページ「マイタイムライン」を作成
- ログイン中のヘッダーメニューに「トップ」と「マイタイムライン」へのリンクを追加

## スクリーンショット

### トップページ

<img width="785" alt="Screen Shot 2020-07-28 at 12 07 55" src="https://user-images.githubusercontent.com/58389623/88614572-faec9000-d0ca-11ea-9b5a-e4703274183a.png">

### ログイン中のユーザー以外のプロフィールページ

<img width="599" alt="Screen Shot 2020-07-28 at 12 09 02" src="https://user-images.githubusercontent.com/58389623/88614645-22435d00-d0cb-11ea-99f8-4399bd8b50f2.png">

### フォローしているユーザーの投稿一覧ページ

<img width="710" alt="Screen Shot 2020-07-28 at 12 09 25" src="https://user-images.githubusercontent.com/58389623/88614664-2f604c00-d0cb-11ea-9b01-95bb2507d367.png">
