### PR TITLE
翻訳の漏れを修正

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -42,7 +42,7 @@
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
-      <em><%= @minimum_password_length %> <%= t("characters minimum") %></em>
+      <em><%= t("devise.shared.minimum_password_length", count: @minimum_password_length) %></em>
     <% end %>
   </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -36,7 +36,7 @@
   <div class="field">
     <%= f.label :password %>
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> <%= t(".characters_minimum") %>)</em>
+    <em><%= t("devise.shared.minimum_password_length", count: @minimum_password_length) %></em>
     <% end %><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
   </div>


### PR DESCRIPTION
ユーザーアカウント登録 / 編集画面の"minimum_password_length"の翻訳を適用