### PR TITLE
日報とコメント機能を実装

### DIFF
--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Books::CommentsController < CommentsController
+  before_action :set_commentable
+
+  private
+    def set_commentable
+      @commentable = Book.find(params[:book_id])
+    end
+end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -28,7 +28,7 @@ class BooksController < ApplicationController
     @book.user_id = current_user.id
 
     if @book.save
-      redirect_to @book, notice: t("flash.create")
+      redirect_to @book, notice: t("flash.create", model: @book.model_name.human)
     else
       render :new
     end
@@ -37,7 +37,7 @@ class BooksController < ApplicationController
   # PATCH/PUT /books/1
   def update
     if @book.update(book_params)
-      redirect_to @book, notice: t("flash.update")
+      redirect_to @book, notice: t("flash.update", model: @book.model_name.human)
     else
       render :edit
     end
@@ -46,7 +46,7 @@ class BooksController < ApplicationController
   # DELETE /books/1
   def destroy
     @book.destroy
-    redirect_to books_url, notice: t("flash.destroy")
+    redirect_to books_url, notice: t("flash.destroy", model: @book.model_name.human)
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CommentsController < ApplicationController
+  before_action :authenticate_user!
+  # POST /comments
+  def create
+    @comment = @commentable.comments.new(comment_params)
+    @comment.user_id = current_user.id
+    @comment.save
+    redirect_to @commentable
+  end
+
+  private
+    def comment_params
+      params.require(:comment).permit(:body)
+    end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,12 +2,20 @@
 
 class CommentsController < ApplicationController
   before_action :authenticate_user!
+
+  def new
+    @comment = @commentable.comments.new
+  end
+
   # POST /comments
   def create
     @comment = @commentable.comments.new(comment_params)
     @comment.user_id = current_user.id
-    @comment.save
-    redirect_to @commentable
+    if @comment.save
+      redirect_to @commentable, notice: t("flash.create", model: @comment.model_name.human)
+    else
+      render :new
+    end
   end
 
   private

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Reports::CommentsController < CommentsController
+  before_action :set_commentable
+
+  private
+    def set_commentable
+      @commentable = Report.find(params[:report_id])
+    end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -44,8 +44,11 @@ class ReportsController < ApplicationController
 
   # DELETE /reports/1
   def destroy
-    @report.destroy
-    redirect_to reports_url, notice: t("flash.destroy", model: @report.model_name.human)
+    if @report.destroy
+      redirect_to reports_url, notice: t("flash.destroy", model: @report.model_name.human)
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -26,7 +26,7 @@ class ReportsController < ApplicationController
     @report = Report.new(report_params)
     @report.user_id = current_user.id
     if @report.save
-      redirect_to @report, notice: "Report was successfully created."
+      redirect_to @report, notice: t("flash.create", model: @report.model_name.human)
     else
       render :new
     end
@@ -35,7 +35,7 @@ class ReportsController < ApplicationController
   # PATCH/PUT /reports/1
   def update
     if @report.update(report_params)
-      redirect_to @report, notice: "Report was successfully updated."
+      redirect_to @report, notice: t("flash.update", model: @report.model_name.human)
     else
       render :edit
     end
@@ -44,7 +44,7 @@ class ReportsController < ApplicationController
   # DELETE /reports/1
   def destroy
     @report.destroy
-    redirect_to reports_url, notice: "Report was successfully destroyed."
+    redirect_to reports_url, notice: t("flash.destroy", model: @report.model_name.human)
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,11 +5,12 @@ class ReportsController < ApplicationController
 
   # GET /reports
   def index
-    @reports = Report.all
+    @reports = Report.page(params[:page])
   end
 
   # GET /reports/1
   def show
+    @report = Report.find(params[:id])
   end
 
   # GET /reports/new

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class ReportsController < ApplicationController
+  before_action :set_report, only: [:show, :edit, :update, :destroy]
+
+  # GET /reports
+  def index
+    @reports = Report.all
+  end
+
+  # GET /reports/1
+  def show
+  end
+
+  # GET /reports/new
+  def new
+    @report = Report.new
+  end
+
+  # GET /reports/1/edit
+  def edit
+  end
+
+  # POST /reports
+  def create
+    @report = Report.new(report_params)
+    @report.user_id = current_user.id
+    if @report.save
+      redirect_to @report, notice: "Report was successfully created."
+    else
+      render :new
+    end
+  end
+
+  # PATCH/PUT /reports/1
+  def update
+    if @report.update(report_params)
+      redirect_to @report, notice: "Report was successfully updated."
+    else
+      render :edit
+    end
+  end
+
+  # DELETE /reports/1
+  def destroy
+    @report.destroy
+    redirect_to reports_url, notice: "Report was successfully destroyed."
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_report
+      @report = Report.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def report_params
+      params.require(:report).permit(:title, :body)
+    end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -3,4 +3,5 @@
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
   belongs_to :user
+  has_many :comments, as: :commentable
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class Comment < ApplicationRecord
+  belongs_to :user
   belongs_to :commentable, polymorphic: true
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  belongs_to :commentable, polymorphic: true
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,4 +2,5 @@
 
 class Report < ApplicationRecord
   belongs_to :user
+  has_many :comments, as: :commentable
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Report < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 class User < ApplicationRecord
   has_one_attached :image
   has_many :books
+  has_many :reports
   has_many :active_relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
   has_many :passive_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
   has_many :following, through: :active_relationships, source: :followed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_one_attached :image
   has_many :books
   has_many :reports
+  has_many :comments
   has_many :active_relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
   has_many :passive_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
   has_many :following, through: :active_relationships, source: :followed

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -29,3 +29,6 @@
   <%= link_to t("link.Edit"), edit_book_path(@book) %> |
 <% end %>
 <%= link_to t("link.Back"), books_path %>
+
+<%= render "comments/comments", commentable: @book %>
+<%= render "comments/form", commentable: @book %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,0 +1,6 @@
+<h3>Comments</h3>
+<% commentable.comments.each do |comment| %>
+  <p>
+    <strong><%= comment.user.name %></strong> : <%= comment.body %>
+  </p>
+<% end %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,4 +1,4 @@
-<h3>Comments</h3>
+<h3><%= t("Comments") %></h3>
 <% commentable.comments.each do |comment| %>
   <p>
     <strong><%= comment.user.name %></strong> : <%= comment.body %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_with(model: [commentable, Comment.new], local: true) do |form| %>
   <div class="field">
-    <%= form.text_area :body, placeholder: "Add a comment" %>
+    <%= form.text_area :body, placeholder: t("Add a comment") %>
   </div>
 
   <div class="actions">
-    <%= form.submit "コメントする" %>
+    <%= form.submit %>
   </div>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with(model: [commentable, Comment.new], local: true) do |form| %>
+  <div class="field">
+    <%= form.text_area :body, placeholder: "Add a comment" %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit "コメントする" %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,6 @@
   <body>
   <p>
     <% if user_signed_in? %>
-      <%= link_to t("Top"), root_path %>
       <%= link_to t("Books"), books_path %>
       <%= link_to t("Reports"), reports_path %>
       <%= link_to t("My Timeline"), timeline_path %> |

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,8 @@
   <p>
     <% if user_signed_in? %>
       <%= link_to t("Top"), root_path %>
+      <%= link_to t("Books"), books_path %>
+      <%= link_to t("Reports"), reports_path %>
       <%= link_to t("My Timeline"), timeline_path %> |
       <%= t("Logged in as") %> <strong><%= link_to current_user.name, user_path(current_user) %></strong>
       <%= link_to t("Edit profile"), edit_user_registration_path %> |

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: report, local: true) do |form| %>
+  <% if report.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(report.errors.count, "error") %> prohibited this report from being saved:</h2>
+
+      <ul>
+        <% report.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :body %>
+    <%= form.text_area :body %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Report</h1>
+
+<%= render 'form', report: @report %>
+
+<%= link_to 'Show', @report %> |
+<%= link_to 'Back', reports_path %>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,6 +1,6 @@
-<h1>Editing Report</h1>
+<h1><%= t("Editing Report") %></h1>
 
-<%= render 'form', report: @report %>
+<%= render "form", report: @report %>
 
-<%= link_to 'Show', @report %> |
-<%= link_to 'Back', reports_path %>
+<%= link_to t("link.Show"), @report %> |
+<%= link_to t("link.Back"), reports_path %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,33 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Reports</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= User.human_attribute_name(:name) %></th>
+      <th><%= Book.human_attribute_name(:title) %></th>
+      <th><%= Book.human_attribute_name(:body) %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @reports.each do |report| %>
+      <tr>
+        <td><%= link_to report.user.name, user_path(report.user) %></td>
+        <td><%= report.title %></td>
+        <td><%= report.body %></td>
+        <td><%= link_to t("link.Show"), report %></td>
+        <% if report.user == current_user %>
+          <td><%= link_to t("link.Edit"), edit_report_path(report) %></td>
+          <td><%= link_to t("link.Destroy"), report, method: :delete, data: { confirm: t("alert.sure") } %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Report', new_report_path %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,13 +1,13 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Reports</h1>
+<h1><%= t("Reports") %></h1>
 
 <table>
   <thead>
     <tr>
       <th><%= User.human_attribute_name(:name) %></th>
-      <th><%= Book.human_attribute_name(:title) %></th>
-      <th><%= Book.human_attribute_name(:body) %></th>
+      <th><%= Report.human_attribute_name(:title) %></th>
+      <th><%= Report.human_attribute_name(:body) %></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to 'New Report', new_report_path %>
+<%= link_to t("link.New Report"), new_report_path %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1><%= t("Reports") %></h1>
 
 <table>
@@ -29,5 +27,6 @@
 </table>
 
 <br>
-
+<%= paginate @reports %>
+<br>
 <%= link_to t("link.New Report"), new_report_path %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Report</h1>
+
+<%= render 'form', report: @report %>
+
+<%= link_to 'Back', reports_path %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Report</h1>
+<h1><%= t("New Report") %></h1>
 
-<%= render 'form', report: @report %>
+<%= render "form", report: @report %>
 
-<%= link_to 'Back', reports_path %>
+<%= link_to t("link.Back"), reports_path %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -12,3 +12,6 @@
 
 <%= link_to 'Edit', edit_report_path(@report) %> |
 <%= link_to 'Back', reports_path %>
+
+<%= render "comments/comments", commentable: @report %>
+<%= render "comments/form", commentable: @report %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,17 +1,17 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Title:</strong>
+  <strong><%= Report.human_attribute_name(:title) %>:</strong>
   <%= @report.title %>
 </p>
 
 <p>
-  <strong>Body:</strong>
+  <strong><%= Report.human_attribute_name(:body) %>:</strong>
   <%= @report.body %>
 </p>
 
-<%= link_to 'Edit', edit_report_path(@report) %> |
-<%= link_to 'Back', reports_path %>
+<%= link_to t("link.Edit"), edit_report_path(@report) %> |
+<%= link_to t("link.Back"), reports_path %>
 
 <%= render "comments/comments", commentable: @report %>
 <%= render "comments/form", commentable: @report %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @report.title %>
+</p>
+
+<p>
+  <strong>Body:</strong>
+  <%= @report.body %>
+</p>
+
+<%= link_to 'Edit', edit_report_path(@report) %> |
+<%= link_to 'Back', reports_path %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -30,15 +30,16 @@ ja:
     Edit: 編集
     Destroy: 削除
   flash:
-    create: "本が保存されました"
-    update: "本が更新されました"
-    destroy: "本が削除されました"
+    create: "%{model}が保存されました"
+    update: "%{model}が更新されました"
+    destroy: "%{model}が削除されました"
   alert:
     sure: "本当によろしいですか？"
   Books: 本
   Reports: 日報
   Comments: コメント
   New Book: 新規作成
+  New Report: 新規作成
   Editing Book: 編集
   Editing Report: 編集
   Add a comment: コメントを追加

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
     models:
       book: 本
       report: 日報
+      comment: コメント
     attributes:
       book:
         title: タイトル

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,17 +9,22 @@ ja:
           has_many: "%{record}が存在しているので削除できません"
     models:
       book: 本
+      report: 日報
     attributes:
       book:
         title: タイトル
         memo: メモ
         author: 著者
         picture: 画像
+      report:
+        title: タイトル
+        body: 本文
       user:
         name: ユーザー名
         image: 画像
   link:
     New Book: 新規作成
+    New Report: 新規作成
     Back: 戻る
     Show: 詳細
     Edit: 編集
@@ -31,10 +36,13 @@ ja:
   alert:
     sure: "本当によろしいですか？"
   Books: 本
+  Reports: 日報
+  Comments: コメント
   New Book: 新規作成
   Editing Book: 編集
+  Editing Report: 編集
+  Add a comment: コメントを追加
   Sign in with GitHub: "GitHubでログイン"
-  Top: トップ
   My Timeline: マイタイムライン
   Follow: フォローする
   Unfollow: フォロー解除

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,12 @@ Rails.application.routes.draw do
     registrations: "users/registrations",
     omniauth_callbacks: "users/omniauth_callbacks"
   }
-  resources :books
-  resources :reports
+  resources :books do
+    resources :comments, module: :books
+  end
+  resources :reports do
+    resources :comments, module: :reports
+  end
   resources :users do
     member do
       get :following, :followers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     omniauth_callbacks: "users/omniauth_callbacks"
   }
   resources :books
+  resources :reports
   resources :users do
     member do
       get :following, :followers

--- a/db/migrate/20200802004411_create_reports.rb
+++ b/db/migrate/20200802004411_create_reports.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateReports < ActiveRecord::Migration[6.0]
+  def change
+    create_table :reports do |t|
+      t.string :title
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200802004602_add_user_id_to_reports.rb
+++ b/db/migrate/20200802004602_add_user_id_to_reports.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUserIdToReports < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :reports, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20200802021755_create_comments.rb
+++ b/db/migrate/20200802021755_create_comments.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.references :commentable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200802030534_add_body_to_comments.rb
+++ b/db/migrate/20200802030534_add_body_to_comments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBodyToComments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comments, :body, :text
+  end
+end

--- a/db/migrate/20200802034912_add_user_id_to_comments.rb
+++ b/db/migrate/20200802034912_add_user_id_to_comments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUserIdToComments < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :comments, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20200812095455_change_column_null_on_comments.rb
+++ b/db/migrate/20200812095455_change_column_null_on_comments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeColumnNullOnComments < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :comments, :body, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_02_034912) do
+ActiveRecord::Schema.define(version: 2020_08_12_095455) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 2020_08_02_034912) do
     t.integer "commentable_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "body"
+    t.text "body", null: false
     t.integer "user_id", null: false
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
     t.index ["user_id"], name: "index_comments_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_25_153426) do
+ActiveRecord::Schema.define(version: 2020_08_02_004602) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -55,6 +55,15 @@ ActiveRecord::Schema.define(version: 2020_07_25_153426) do
     t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
+  create_table "reports", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "encrypted_password", null: false
@@ -76,4 +85,5 @@ ActiveRecord::Schema.define(version: 2020_07_25_153426) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "books", "users"
+  add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_02_021755) do
+ActiveRecord::Schema.define(version: 2020_08_02_034912) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -50,7 +50,10 @@ ActiveRecord::Schema.define(version: 2020_08_02_021755) do
     t.integer "commentable_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "body"
+    t.integer "user_id", null: false
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "relationships", force: :cascade do |t|
@@ -93,5 +96,6 @@ ActiveRecord::Schema.define(version: 2020_08_02_021755) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "books", "users"
+  add_foreign_key "comments", "users"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_02_004602) do
+ActiveRecord::Schema.define(version: 2020_08_02_021755) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -43,6 +43,14 @@ ActiveRecord::Schema.define(version: 2020_08_02_004602) do
     t.string "picture"
     t.integer "user_id", null: false
     t.index ["user_id"], name: "index_books_on_user_id"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.string "commentable_type", null: false
+    t.integer "commentable_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
   end
 
   create_table "relationships", force: :cascade do |t|


### PR DESCRIPTION
## 内容

- 日報機能（一覧、個別、作成、編集、削除）を実装
- 日報（Report）とユーザー（User）を関連付け
- 日報と本、それぞれにコメント投稿機能実装
- コメント（Comment）とユーザー（User）を関連付け
- ヘッダーメニューに「日報」へのリンクを追加

## スクリーンショット

### 日報の一覧ページ

<img width="598" alt="Screen Shot 2020-08-02 at 18 16 00" src="https://user-images.githubusercontent.com/58389623/89119836-3a144a00-d4ec-11ea-96d7-582a7529446c.png">

### コメント機能（日報の詳細ページ）

<img width="600" alt="Screen Shot 2020-08-02 at 18 17 50" src="https://user-images.githubusercontent.com/58389623/89119873-7ba4f500-d4ec-11ea-95a7-17a73b9228ee.png">

### コメント機能（本の詳細ページ）

<img width="595" alt="Screen Shot 2020-08-02 at 18 18 51" src="https://user-images.githubusercontent.com/58389623/89119896-9f683b00-d4ec-11ea-9f3a-1bc07ce88c3d.png">